### PR TITLE
Bug fix release 4.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Remote file is now before notification friendly (fixes #33)
 - Stop using non-documented argument for nssm dump (fixes #34)
+- Fixed a bug where AppExit needs a subparameter on reset
 
 ## 4.0.0 2017-08-02
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # NSSM CHANGELOG
 
+## 4.0.1 2018-01-24
+
+- Remote file is now before notification friendly (fixes #33)
+- Stop using non-documented argument for nssm dump (fixes #34)
+
 ## 4.0.0 2017-08-02
 
 - Convert default recipe to custom resource with idempotence 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # NSSM CHANGELOG
 
-## 4.0.1 2018-01-24
+## 4.0.1 2018-07-24
 
 - Remote file is now before notification friendly (fixes #33)
 - Stop using non-documented argument for nssm dump (fixes #34)

--- a/metadata.rb
+++ b/metadata.rb
@@ -6,9 +6,9 @@ maintainer_email 'dennis.hoer@gmail.com'
 license 'MIT'
 description 'Installs/Configures NSSM'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-source_url 'https://github.com/dhoer/chef-nssm'
-issues_url 'https://github.com/dhoer/chef-nssm/issues'
-version '4.0.0'
+source_url 'https://github.com/criteo-cookbooks/nssm'
+issues_url 'https://github.com/criteo-cookbooks/nssm/issues'
+version '4.0.1'
 
 chef_version '>= 12.7'
 


### PR DESCRIPTION
## 4.0.1 2018-01-24

- Remote file is now before notification friendly (fixes #33)
- Stop using non-documented argument for nssm dump (fixes #34)
- Fixed a bug where AppExit needs a subparameter on reset 
- Updated URLs to new repo location, changelog and  version bump