### PR TITLE
Bump chef to 15+ and remove dependency to windows cookbook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # NSSM CHANGELOG
 
+## 5.0.0 2021-10-28
+
+- Depends on Chef 15+
+- Remove dependency on Windows cookbook
+
 ## 4.0.1 2018-07-25
 
 - Remote file is now before notification friendly (fixes #33)

--- a/metadata.rb
+++ b/metadata.rb
@@ -1,14 +1,14 @@
 # frozen_string_literal: true
 
 name 'nssm'
-maintainer 'Dennis Hoer'
-maintainer_email 'dennis.hoer@gmail.com'
+maintainer 'Criteo'
+maintainer_email 'systems-services-team@criteo.com'
 license 'MIT'
 description 'Installs/Configures NSSM'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 source_url 'https://github.com/criteo-cookbooks/nssm'
 issues_url 'https://github.com/criteo-cookbooks/nssm/issues'
-version '4.0.1'
+version '5.0.0'
 
 chef_version '>= 15.0'
 

--- a/metadata.rb
+++ b/metadata.rb
@@ -10,7 +10,6 @@ source_url 'https://github.com/criteo-cookbooks/nssm'
 issues_url 'https://github.com/criteo-cookbooks/nssm/issues'
 version '4.0.1'
 
-chef_version '>= 12.7'
+chef_version '>= 15.0'
 
 supports 'windows'
-depends 'windows'

--- a/resources/install.rb
+++ b/resources/install.rb
@@ -8,17 +8,29 @@ default_action :install
 action :install do
   src = new_resource.source
   basename = src.slice(src.rindex('/') + 1, src.rindex('.') - src.rindex('/') - 1)
+  download_path = "#{Chef::Config[:file_cache_path]}/#{basename}.zip"
+  extract_path = "#{Chef::Config[:file_cache_path]}/#{basename}"
   system = node['kernel']['machine'] == 'x86_64' ? 'win64' : 'win32'
-  system_file = "#{Chef::Config[:file_cache_path]}/#{basename}/#{system}/nssm.exe"
+  system_file = "#{extract_path}/#{basename}/#{system}/nssm.exe"
 
-  windows_zipfile 'download nssm' do
-    path Chef::Config[:file_cache_path]
-    source src
-    overwrite true
+  remote_file 'download nssm' do
     checksum new_resource.sha256
-    action :unzip
+    path download_path
+    source src
     notifies :create, 'remote_file[install nssm]', :immediately
-    not_if { Digest::SHA256.file("#{Chef::Config[:file_cache_path]}/#{basename}.zip").hexdigest == new_resource.sha256 } if ::File.exist?("#{Chef::Config[:file_cache_path]}/#{basename}.zip")
+  end
+
+  directory extract_path do
+    action :nothing
+    recursive true
+    subscribes :delete, 'remote_file[download nssm]', :before
+  end
+
+  archive_file 'extract nssm' do
+    action :extract
+    destination extract_path
+    overwrite false
+    path download_path
   end
 
   remote_file 'install nssm' do

--- a/spec/unit/default_spec.rb
+++ b/spec/unit/default_spec.rb
@@ -19,19 +19,20 @@ describe 'nssm::default' do
       )
     end
 
-    it 'download nssm' do
-      expect(chef_run).to unzip_windows_zipfile('download nssm').with(
-        path: CACHE,
+    it 'downloads nssm' do
+      expect(chef_run).to create_remote_file('download nssm').with(
+        path: "#{CACHE}/nssm-#{VERSION}.zip",
         source: "https://nssm.cc/ci/nssm-#{VERSION}.zip"
       )
     end
 
-    it 'install nssm' do
+    it 'installs nssm' do
       allow(::File).to receive(:exist?).and_call_original
-      expect(::File).to receive(:exist?).with("#{CACHE}/nssm-2.24-94-g9c88bc1/win64/nssm.exe").and_return true
+      expect(::File).to receive(:exist?).with("#{CACHE}/nssm-#{VERSION}/nssm-#{VERSION}/win64/nssm.exe").and_return true
+
       expect(chef_run).to create_remote_file('install nssm').with(
         path: "C:\\tmp\\nssm-#{VERSION}.exe",
-        source: "file:///#{CACHE}/nssm-2.24-94-g9c88bc1/win64/nssm.exe"
+        source: "file:///#{CACHE}/nssm-#{VERSION}/nssm-#{VERSION}/win64/nssm.exe"
       )
     end
   end


### PR DESCRIPTION
Chef < 15 are EOL and `windows` cookbook is deprecated.
Chef 15+ provides an `archive_file` resource which can help to replace the former `windows_zipfile`